### PR TITLE
Fix to DS9FX mod conflicting with FoundationTechnologies phased techs

### DIFF
--- a/scripts/Custom/DS9FX/DS9FXMutatorFunctions.py
+++ b/scripts/Custom/DS9FX/DS9FXMutatorFunctions.py
@@ -136,6 +136,28 @@ def HandleNoDamageThroughShields(param, pObject, pEvent):
                 HandleShields.ShipCreated(pObject, pEvent)
         elif param == "WeaponHit":
                 HandleShields.WeaponHit(pObject, pEvent)
+               
+        
+def HandleNoDamageThroughShields(param, pObject, pEvent):
+        reload (DS9FXSavedConfig)
+        if not DS9FXSavedConfig.NoDamageThroughShields == 1:
+                return         
+    
+        if param == "ShipCreated":
+                HandleShields.ShipCreated(pObject, pEvent)
+        elif param == "WeaponHit":
+                isthisPhased = 0 # Alex SL Gato: Taking into account phased weaponry
+                pWeaponType = pEvent.GetWeaponType()
+                if pWeaponType == pEvent.TORPEDO: # Fixing how this mod conflicts with PhasedTorp and any kind of similar stock and modded technologies
+                        try:
+                                pTorp=App.Torpedo_Cast(pEvent.GetSource())
+                                # pTorp.GetNetType() == Multiplayer.SpeciesToTorp.PHASEDPLASMA
+                                if pTorp.GetNetType() == 12:
+                                        isthisPhased = 1
+                        except:
+                                isthisPhased = 0
+                if isthisPhased == 0:
+                        HandleShields.WeaponHit(pObject, pEvent)
 
 def HandleLifeSupportNewShip(pObject, pEvent):
         reload (DS9FXSavedConfig)

--- a/scripts/Custom/DS9FX/DS9FXMutatorFunctions.py
+++ b/scripts/Custom/DS9FX/DS9FXMutatorFunctions.py
@@ -125,18 +125,7 @@ def CleanDelay(pAction):
 def ShipCreatedHandling(pObject, pEvent):
         BorgShips.BorgShipCheck(pObject, pEvent)
         HandleLifeSupportNewShip(pObject, pEvent)
-        HandleNoDamageThroughShields("ShipCreated", pObject, pEvent)
-
-def HandleNoDamageThroughShields(param, pObject, pEvent):
-        reload (DS9FXSavedConfig)
-        if not DS9FXSavedConfig.NoDamageThroughShields == 1:
-                return 
-
-        if param == "ShipCreated":
-                HandleShields.ShipCreated(pObject, pEvent)
-        elif param == "WeaponHit":
-                HandleShields.WeaponHit(pObject, pEvent)
-               
+        HandleNoDamageThroughShields("ShipCreated", pObject, pEvent)      
         
 def HandleNoDamageThroughShields(param, pObject, pEvent):
         reload (DS9FXSavedConfig)


### PR DESCRIPTION
As you may be aware, the current HandleNoDamageThroughShields makes it so absolutely no weapon can bypass the shields. This is fine at first. Problem comes for when a weapon is actually meant to do that like the Phased Plasma Torpedoes (including the stock ones). Those techs work on the concept of the torpedo "bypassing" the shield and dealing the stat and visual damage they would apply normally, so the torpedo actually hits the hull and deals the damage to the ship as if the shield was not there. The handler as it was previously made all those mods (as well as the stock function) inoperable. Before I knew DS9FX was being updated to newer versions, I made a patch for the 1.0 DS9FX file, but knowing how this project is still very much alive (thank you for informing me), I decided to just do the update here as a commit to fix the issue permanently and without breaking someone's different DS9FX version.

IMPORTANT NOTE: The phased weaponry is NOT how drones from the stargate pack work, those use a far inferior mock which only targets a single subsystem at a time and never deals visible damage. The real phased weaponry works as how the literal torpedo would have acted if there was no shield on the first place.